### PR TITLE
Fix PyInstaller module issue in README and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Uninstall
 Troubleshooting
 - If Inno Setup can’t find the executable, run Step 1 to produce dist\AI_Crawler_Assistant_Server.exe
 - If PyInstaller build fails, ensure templates\ exists and rerun scripts\build_windows.bat
+- Error: "python.exe: No module named pyinstaller"
+  - Cause: PyInstaller isn’t installed in the active Python/venv.
+  - Fix (inside your venv): `python -m pip install --upgrade pip && python -m pip install pyinstaller`
+  - Or run the provided builder which installs it automatically: `scripts\build_windows.bat`
 - To include additional assets, adjust the --add-data flag in scripts\build_windows.bat and corresponding [Files] entries in installers\inno_setup\installer.iss
 
 Run the Server (Linux/macOS/Windows)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ jinja2>=3.1.2
 sse-starlette>=1.6.5
 transformers>=4.41.0
 croniter>=1.4.1
+pyinstaller>=6.16.0


### PR DESCRIPTION
This pull request addresses the issue related to the error 'python.exe: No module named pyinstaller' by updating the README.md file with troubleshooting steps for installing PyInstaller and ensuring the correct environment setup. Additionally, PyInstaller has been added to the requirements.txt file to ensure it is included in the package dependencies. This should help users avoid installation issues related to PyInstaller when building the application.

---

> This pull request was co-created with Cosine Genie

Original Task: [AI-Crawler/jxp87ahvflu3](https://cosine.sh/sywt8ah7e7gq/AI-Crawler/task/jxp87ahvflu3)
Author: foxcube3
